### PR TITLE
Add hex escaped GLOBALS to RegExp

### DIFF
--- a/manager/evocheck.php
+++ b/manager/evocheck.php
@@ -426,7 +426,7 @@ class EvoCheck {
 	function setTemplates()
 	{
 		$summary_length = $this->summary_length ? $this->summary_length : 100;
-		$search_term = $this->search_term ? $this->search_term : '((\d+)\h*\/\h*(\d+)|base64_decode\h*\(|eval\h*\(|system\h*\(|shell_exec\h*\(|<\?php[^\n]{200,}|\$GLOBALS\[\$GLOBALS\[|;\h*\$GLOBALS|\$GLOBALS\h*;)';
+		$search_term = $this->search_term ? $this->search_term : '((\d+)\h*\/\h*(\d+)|base64_decode\h*\(|eval\h*\(|system\h*\(|shell_exec\h*\(|<\?php[^\n]{200,}|\$GLOBALS\[\$GLOBALS\[|;\h*\$GLOBALS|\$GLOBALS\h*;|\${.?\\\x47\\\x4c\\\x4f\\\x42\\\x41\\\x4c\\\x53.?})';
 		$criteria_db = $this->criteria_db ? $this->criteria_db : array('plugin','snippet');
 		$criteria_f = $this->criteria_f ? $this->criteria_f : array();
 


### PR DESCRIPTION
As your search term looks for all kinds of `$GLOBALS`, I like to add `\${.?\\\x47\\\x4c\\\x4f\\\x42\\\x41\\\x4c\\\x53.?}` to the default search term. It matches `${"\x47\x4c\x4f\x42\x41\x4c\x53"}` which is equal to `${"GLOBALS"}` and which I found in a hack on my index.php.

By the way, what is `(\d+)\h*\/\h*(\d+)`supposed to do. It matches a lot of files, because they have a english date in it... I always get rid of it before searching files.